### PR TITLE
Updated to include condition key for iam Passrole

### DIFF
--- a/doc_source/security_iam_resource-based-policy-examples.md
+++ b/doc_source/security_iam_resource-based-policy-examples.md
@@ -41,7 +41,11 @@ To access the AWS Elemental MediaConnect console, you must have a policy that de
                 "iam:PassRole"
             ],
             "Effect": "Allow",
-            "Resource": "*"
+            "Resource": "*",
+            "Condition": {
+                "StringLike": {
+                    "iam:PassedToService": "mediaconnect.amazonaws.com"
+            }
         }
     ]
 }
@@ -85,7 +89,11 @@ Every user of AWS Elemental MediaConnect must have a policy that defines permiss
                 "iam:PassRole"
             ],
             "Effect": "Allow",
-            "Resource": "*"
+            "Resource": "*",
+            "Condition": {
+                "StringLike": {
+                    "iam:PassedToService": "mediaconnect.amazonaws.com"
+            }
         }
     ]
 }

--- a/doc_source/security_iam_resource-based-policy-examples.md
+++ b/doc_source/security_iam_resource-based-policy-examples.md
@@ -46,6 +46,7 @@ To access the AWS Elemental MediaConnect console, you must have a policy that de
                 "StringLike": {
                     "iam:PassedToService": "mediaconnect.amazonaws.com"
             }
+          }
         }
     ]
 }
@@ -93,7 +94,8 @@ Every user of AWS Elemental MediaConnect must have a policy that defines permiss
             "Condition": {
                 "StringLike": {
                     "iam:PassedToService": "mediaconnect.amazonaws.com"
-            }
+             }
+           } 
         }
     ]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
iam:PassRole with wildcard resource opens up to pass any role. Updated to scope only for MediaConnect.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
